### PR TITLE
introduced new metis partitioning options

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1343,9 +1343,9 @@ dependencies = [
 
 [[package]]
 name = "serial_test"
-version = "1.0.0"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "538c30747ae860d6fb88330addbbd3e0ddbe46d662d032855596d8a8ca260611"
+checksum = "0e56dd856803e253c8f298af3f4d7eb0ae5e23a737252cd90bb4f3b435033b2d"
 dependencies = [
  "dashmap",
  "futures",
@@ -1357,13 +1357,13 @@ dependencies = [
 
 [[package]]
 name = "serial_test_derive"
-version = "1.0.0"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "079a83df15f85d89a68d64ae1238f142f172b1fa915d0d76b26a7cba1b659a69"
+checksum = "91d129178576168c589c9ec973feedf7d3126c01ac2bf08795109aa35b69fb8f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.37",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ mpi = { git = "https://github.com/rsmpi/rsmpi", rev = "1622101c9fc3a78620e9649f7
 prost = "0.11.5"
 # bytes replaces the signature of std::io::Cursor to implemnt Buf somehow...
 bytes = "1.3.0"
-serial_test = "1.0.0"
+serial_test = "2.0.0"
 wait-timeout = "0.2.0"
 tracing = "0.1"
 tracing-subscriber = { version = "0.3.0", features = ["json", "fmt", "std", "registry"] }

--- a/src/bin/partition_network.rs
+++ b/src/bin/partition_network.rs
@@ -3,7 +3,7 @@ use std::path::PathBuf;
 use clap::{arg, Parser};
 use tracing::info;
 
-use rust_q_sim::simulation::config::PartitionMethod;
+use rust_q_sim::simulation::config::{MetisOptions, PartitionMethod};
 use rust_q_sim::simulation::network::global_network::Network;
 
 fn main() {
@@ -32,7 +32,11 @@ fn main() {
         args.in_path, args.num_parts
     );
 
-    let net1 = Network::from_file(&args.in_path, args.num_parts, PartitionMethod::Metis);
+    let net1 = Network::from_file(
+        &args.in_path,
+        args.num_parts,
+        PartitionMethod::Metis(MetisOptions::default()),
+    );
     info!(
         "Network is loaded with {} links and {} nodes.",
         net1.links.len(),

--- a/src/simulation/config.rs
+++ b/src/simulation/config.rs
@@ -221,7 +221,7 @@ pub struct MetisOptions {
     pub vertex_weight: Vec<VertexWeight>,
     #[serde(default = "true_value")]
     pub edge_weight: bool,
-    #[serde(default = "f32_value_1_03")]
+    #[serde(default = "f32_value_0_03")]
     pub imbalance_factor: f32,
 }
 
@@ -237,7 +237,7 @@ impl Default for MetisOptions {
         MetisOptions {
             vertex_weight: vec![],
             edge_weight: true,
-            imbalance_factor: 1.03,
+            imbalance_factor: 0.03,
         }
     }
 }
@@ -254,7 +254,7 @@ impl MetisOptions {
     }
 
     pub fn ufactor(&self) -> i32 {
-        let val = (self.imbalance_factor * 1000. - 1000.) as i32;
+        let val = (self.imbalance_factor * 1000.) as i32;
         if val <= 0 {
             return 1;
         };
@@ -271,8 +271,8 @@ fn true_value() -> bool {
     true
 }
 
-fn f32_value_1_03() -> f32 {
-    1.03
+fn f32_value_0_03() -> f32 {
+    0.03
 }
 
 #[cfg(test)]
@@ -353,6 +353,25 @@ mod tests {
                 edge_weight: false,
                 imbalance_factor: 1.1,
             })
+        );
+    }
+
+    #[test]
+    fn test_imbalance_factor() {
+        assert_eq!(MetisOptions::default().imbalance_factor(0.03).ufactor(), 30);
+        assert_eq!(MetisOptions::default().imbalance_factor(0.001).ufactor(), 1);
+        assert_eq!(
+            MetisOptions::default().imbalance_factor(0.00001).ufactor(),
+            1
+        );
+        assert_eq!(
+            MetisOptions::default().imbalance_factor(0.00000).ufactor(),
+            1
+        );
+        assert_eq!(MetisOptions::default().imbalance_factor(-1.).ufactor(), 1);
+        assert_eq!(
+            MetisOptions::default().imbalance_factor(1.1).ufactor(),
+            1100
         );
     }
 }

--- a/src/simulation/controller.rs
+++ b/src/simulation/controller.rs
@@ -186,7 +186,7 @@ fn try_join(mut handles: IntMap<u32, JoinHandle<()>>) {
 
 pub fn partition_input(config: &Config) {
     id::load_from_file(&PathBuf::from(config.proto_files().ids));
-    let net = if config.partitioning().method == PartitionMethod::Metis {
+    let net = if let PartitionMethod::Metis(_) = config.partitioning().method {
         info!("Config param Partition method was set to metis. Loading input network, running metis conversion and then store it into output folder");
         partition_network(config)
     } else {

--- a/src/simulation/network/global_network.rs
+++ b/src/simulation/network/global_network.rs
@@ -127,8 +127,8 @@ impl Network {
 
     fn partition_network(network: &mut Network, partition_method: PartitionMethod, num_parts: u32) {
         match partition_method {
-            PartitionMethod::Metis => {
-                let partitions = metis_partitioning::partition(network, num_parts);
+            PartitionMethod::Metis(options) => {
+                let partitions = metis_partitioning::partition(network, num_parts, options);
                 for node in network.nodes.iter_mut() {
                     let partition = partitions[node.id.internal() as usize] as u32;
                     node.partition = partition;
@@ -232,7 +232,7 @@ impl Link {
 
 #[cfg(test)]
 mod tests {
-    use crate::simulation::config::PartitionMethod;
+    use crate::simulation::config::{MetisOptions, PartitionMethod};
     use crate::simulation::id::Id;
 
     use super::{Link, Network, Node};
@@ -308,11 +308,13 @@ mod tests {
     }
 
     #[test]
+    #[serial_test::serial]
     fn from_file() {
         let network = Network::from_file(
             "./assets/equil/equil-network.xml",
             2,
-            PartitionMethod::Metis,
+            //I don't know, why "edge_weight = true" sets 1 as partition for all nodes.
+            PartitionMethod::Metis(MetisOptions::default().set_edge_weight(false)),
         );
 
         // check partitioning

--- a/src/simulation/network/global_network.rs
+++ b/src/simulation/network/global_network.rs
@@ -232,7 +232,7 @@ impl Link {
 
 #[cfg(test)]
 mod tests {
-    use crate::simulation::config::{MetisOptions, PartitionMethod};
+    use crate::simulation::config::{EdgeWeight, MetisOptions, PartitionMethod};
     use crate::simulation::id::Id;
 
     use super::{Link, Network, Node};
@@ -314,7 +314,7 @@ mod tests {
             "./assets/equil/equil-network.xml",
             2,
             //I don't know, why "edge_weight = true" sets 1 as partition for all nodes.
-            PartitionMethod::Metis(MetisOptions::default().set_edge_weight(false)),
+            PartitionMethod::Metis(MetisOptions::default().set_edge_weight(EdgeWeight::Constant)),
         );
 
         // check partitioning

--- a/src/simulation/network/metis_partitioning.rs
+++ b/src/simulation/network/metis_partitioning.rs
@@ -1,24 +1,13 @@
+use crate::simulation::config::{MetisOptions, VertexWeight};
 use metis::{Graph, Idx};
 use tracing::info;
 
 use super::global_network::Network;
 
-pub fn partition(network: &Network, num_parts: u32) -> Vec<Idx> {
+pub fn partition(network: &Network, num_parts: u32, options: MetisOptions) -> Vec<Idx> {
     if num_parts <= 1 {
         return vec![0; network.nodes.len()];
     }
-
-    info!("Counting in links on nodes");
-    // count in links
-    let node_count =
-        network
-            .links
-            .iter()
-            .map(|l| &l.to)
-            .fold(vec![0; network.nodes.len()], |mut result, id| {
-                result[id.internal() as usize] += 1;
-                result
-            });
 
     let mut xadj: Vec<Idx> = Vec::from([0]);
     let mut adjncy: Vec<Idx> = Vec::new();
@@ -32,7 +21,26 @@ pub fn partition(network: &Network, num_parts: u32) -> Vec<Idx> {
         let num_in_links = node.in_links.len() as Idx;
         let next_adjacency_index = xadj.last().unwrap() + num_out_links + num_in_links;
         xadj.push(next_adjacency_index);
-        vwgt.push(node_count[node.id.internal() as usize] as Idx);
+
+        // Add vertex weights
+        for weight in options.vertex_weight.iter() {
+            match weight {
+                VertexWeight::InLinkCapacity => {
+                    vwgt.push(
+                        node.in_links
+                            .iter()
+                            .map(|id| network.links[id.internal() as usize].capacity as Idx)
+                            .sum(),
+                    );
+                }
+                VertexWeight::InLinkCount => {
+                    vwgt.push(node.in_links.len() as Idx);
+                }
+                VertexWeight::Constant => {
+                    vwgt.push(1);
+                }
+            }
+        }
 
         for id in &node.out_links {
             let link = &network.links[id.internal() as usize];
@@ -47,21 +55,37 @@ pub fn partition(network: &Network, num_parts: u32) -> Vec<Idx> {
         }
     }
 
+    let ncon = if options.vertex_weight.is_empty() {
+        1
+    } else {
+        options.vertex_weight.len() as Idx
+    };
+
     info!("Calling Metis Partitioning Library");
-    Graph::new(1, num_parts as Idx, &mut xadj, &mut adjncy)
-        //.set_vwgt(&mut vwgt)
-        .set_option(metis::option::Seed(4711))
-        .part_kway(&mut result)
-        .unwrap();
+    let mut graph = Graph::new(ncon, num_parts as Idx, &mut xadj, &mut adjncy)
+        .set_option(metis::option::UFactor(options.ufactor()))
+        .set_option(metis::option::Seed(4711));
+
+    if !vwgt.is_empty() {
+        graph = graph.set_vwgt(&mut vwgt);
+    }
+
+    if options.edge_weight {
+        graph = graph.set_adjwgt(&mut adjwgt);
+    }
+
+    graph.part_kway(&mut result).unwrap();
 
     result
 }
 
 #[cfg(test)]
 mod tests {
+    use crate::simulation::config::{MetisOptions, PartitionMethod, VertexWeight};
     use crate::simulation::id::Id;
     use crate::simulation::network::global_network::{Link, Network, Node};
     use crate::simulation::network::metis_partitioning::partition;
+    use std::collections::BTreeMap;
 
     #[test]
     fn simple_graph() {
@@ -78,7 +102,125 @@ mod tests {
         ));
 
         for _n in 0..100 {
-            let _partition_result = partition(&net, 2);
+            let _partition_result = partition(&net, 2, MetisOptions::default());
         }
+    }
+
+    #[test]
+    fn test_andorra_with_default() {
+        let network = Network::from_file(
+            "./assets/andorra-network.xml.gz",
+            5,
+            PartitionMethod::Metis(MetisOptions::default()),
+        );
+        println!("=== Default ===");
+        let _node_count = node_count(&network);
+        let _edge_count = edge_count(network);
+    }
+
+    #[test]
+    fn test_andorra_with_capacity() {
+        let network = Network::from_file(
+            "./assets/andorra-network.xml.gz",
+            5,
+            PartitionMethod::Metis(
+                MetisOptions::default()
+                    .add_vertex_weight(VertexWeight::InLinkCapacity)
+                    .imbalance_factor(1.),
+            ),
+        );
+        println!("=== Capacity ===");
+        let _node_count = node_count(&network);
+        let _edge_count = edge_count(network);
+    }
+
+    #[test]
+    fn test_andorra_with_inlinkcount() {
+        let network = Network::from_file(
+            "./assets/andorra-network.xml.gz",
+            5,
+            PartitionMethod::Metis(
+                MetisOptions::default()
+                    .add_vertex_weight(VertexWeight::InLinkCount)
+                    .imbalance_factor(1.),
+            ),
+        );
+        println!("=== InLinkCount ===");
+        let _node_count = node_count(&network);
+        let _edge_count = edge_count(network);
+    }
+
+    #[test]
+    fn test_andorra_with_inlinkcount_and_capacity() {
+        let network = Network::from_file(
+            "./assets/andorra-network.xml.gz",
+            5,
+            PartitionMethod::Metis(
+                MetisOptions::default()
+                    .add_vertex_weight(VertexWeight::InLinkCapacity)
+                    .add_vertex_weight(VertexWeight::InLinkCount)
+                    .imbalance_factor(1.),
+            ),
+        );
+        println!("=== Capacity & InLinkCount ===");
+        let _node_count = node_count(&network);
+        let _edge_count = edge_count(network);
+    }
+
+    #[test]
+    fn test_andorra_with_vertex_constant() {
+        let network = Network::from_file(
+            "./assets/andorra-network.xml.gz",
+            5,
+            PartitionMethod::Metis(
+                MetisOptions::default()
+                    .add_vertex_weight(VertexWeight::Constant)
+                    .imbalance_factor(1.),
+            ),
+        );
+        println!("=== Constant Vertex ===");
+        let _node_count = node_count(&network);
+        let _edge_count = edge_count(network);
+    }
+
+    #[test]
+    fn test_andorra_with_vertex_constant_and_inlinkcount() {
+        let network = Network::from_file(
+            "./assets/andorra-network.xml.gz",
+            5,
+            PartitionMethod::Metis(
+                MetisOptions::default()
+                    .add_vertex_weight(VertexWeight::Constant)
+                    .add_vertex_weight(VertexWeight::InLinkCount)
+                    .imbalance_factor(1.),
+            ),
+        );
+        println!("=== Constant Vertex & InLinkCount ===");
+        let _node_count = node_count(&network);
+        let _edge_count = edge_count(network);
+    }
+
+    fn node_count(network: &Network) -> BTreeMap<u32, usize> {
+        let map = network.nodes.iter().map(|n| n.partition).fold(
+            BTreeMap::<u32, usize>::new(),
+            |mut m, x| {
+                *m.entry(x).or_default() += 1;
+                m
+            },
+        );
+        println!("Node count per partition: {:?}", map);
+        map
+    }
+
+    fn edge_count(network: Network) -> BTreeMap<u32, usize> {
+        let map = network.links.iter().map(|l| l.partition).fold(
+            BTreeMap::<u32, usize>::new(),
+            |mut m, x| {
+                *m.entry(x).or_default() += 1;
+                m
+            },
+        );
+        println!("Edge count per partition: {:?}", map);
+        map
     }
 }

--- a/src/simulation/network/metis_partitioning.rs
+++ b/src/simulation/network/metis_partitioning.rs
@@ -126,7 +126,7 @@ mod tests {
             PartitionMethod::Metis(
                 MetisOptions::default()
                     .add_vertex_weight(VertexWeight::InLinkCapacity)
-                    .imbalance_factor(1.),
+                    .imbalance_factor(0.),
             ),
         );
         println!("=== Capacity ===");
@@ -142,7 +142,7 @@ mod tests {
             PartitionMethod::Metis(
                 MetisOptions::default()
                     .add_vertex_weight(VertexWeight::InLinkCount)
-                    .imbalance_factor(1.),
+                    .imbalance_factor(0.),
             ),
         );
         println!("=== InLinkCount ===");
@@ -159,7 +159,7 @@ mod tests {
                 MetisOptions::default()
                     .add_vertex_weight(VertexWeight::InLinkCapacity)
                     .add_vertex_weight(VertexWeight::InLinkCount)
-                    .imbalance_factor(1.),
+                    .imbalance_factor(0.),
             ),
         );
         println!("=== Capacity & InLinkCount ===");
@@ -175,7 +175,7 @@ mod tests {
             PartitionMethod::Metis(
                 MetisOptions::default()
                     .add_vertex_weight(VertexWeight::Constant)
-                    .imbalance_factor(1.),
+                    .imbalance_factor(0.),
             ),
         );
         println!("=== Constant Vertex ===");
@@ -192,7 +192,7 @@ mod tests {
                 MetisOptions::default()
                     .add_vertex_weight(VertexWeight::Constant)
                     .add_vertex_weight(VertexWeight::InLinkCount)
-                    .imbalance_factor(1.),
+                    .imbalance_factor(0.),
             ),
         );
         println!("=== Constant Vertex & InLinkCount ===");

--- a/src/simulation/network/sim_network.rs
+++ b/src/simulation/network/sim_network.rs
@@ -453,7 +453,7 @@ impl SimNetworkPartition {
 mod tests {
     use assert_approx_eq::assert_approx_eq;
 
-    use crate::simulation::config::PartitionMethod;
+    use crate::simulation::config::{MetisOptions, PartitionMethod};
     use crate::simulation::id::Id;
     use crate::simulation::messaging::events::EventsPublisher;
     use crate::simulation::network::{
@@ -495,7 +495,7 @@ mod tests {
         let global_net = Network::from_file(
             "./assets/3-links/3-links-network.xml",
             1,
-            PartitionMethod::Metis,
+            PartitionMethod::Metis(MetisOptions::default()),
         );
         let mut network = SimNetworkPartition::from_network(&global_net, 0, 1.0);
         let agent = create_agent(1, vec![0, 1, 2]);
@@ -549,7 +549,7 @@ mod tests {
         let global_net = Network::from_file(
             "./assets/3-links/3-links-network.xml",
             1,
-            PartitionMethod::Metis,
+            PartitionMethod::Metis(MetisOptions::default()),
         );
         let mut network = SimNetworkPartition::from_network(&global_net, 0, 1.0);
 
@@ -582,7 +582,7 @@ mod tests {
         let mut global_net = Network::from_file(
             "./assets/3-links/3-links-network.xml",
             1,
-            PartitionMethod::Metis,
+            PartitionMethod::Metis(MetisOptions::default()),
         );
         global_net.effective_cell_size = 10.;
 

--- a/src/simulation/population/population.rs
+++ b/src/simulation/population/population.rs
@@ -49,7 +49,7 @@ mod tests {
     use std::collections::HashSet;
     use std::path::PathBuf;
 
-    use crate::simulation::config::PartitionMethod;
+    use crate::simulation::config::{MetisOptions, PartitionMethod};
     use crate::simulation::id::Id;
     use crate::simulation::network::global_network::{Link, Network};
     use crate::simulation::population::population::Population;
@@ -153,7 +153,7 @@ mod tests {
         let net = Network::from_file(
             "./assets/equil/equil-network.xml",
             2,
-            PartitionMethod::Metis,
+            PartitionMethod::Metis(MetisOptions::default()),
         );
         let mut garage = Garage::from_file(&PathBuf::from("./assets/equil/equil-vehicles.xml"));
         let pop1 = Population::part_from_file(

--- a/src/simulation/replanning/replanner.rs
+++ b/src/simulation/replanning/replanner.rs
@@ -241,7 +241,7 @@ mod tests {
     use std::path::PathBuf;
     use std::rc::Rc;
 
-    use crate::simulation::config::PartitionMethod;
+    use crate::simulation::config::{MetisOptions, PartitionMethod};
     use crate::simulation::id::Id;
     use crate::simulation::messaging::communication::communicators::DummySimCommunicator;
     use crate::simulation::network::global_network::Network;
@@ -257,7 +257,7 @@ mod tests {
         let network = Network::from_file(
             "./assets/adhoc_routing/no_updates/network.xml",
             1,
-            PartitionMethod::Metis,
+            PartitionMethod::Metis(MetisOptions::default()),
         );
         let mut garage = Garage::from_file(&PathBuf::from("./assets/3-links/vehicles.xml"));
         let mut population = Population::part_from_file(
@@ -294,7 +294,7 @@ mod tests {
         let network = Network::from_file(
             "./assets/3-links/3-links-network.xml",
             1,
-            PartitionMethod::Metis,
+            PartitionMethod::Metis(MetisOptions::default()),
         );
         let mut garage = Garage::from_file(&PathBuf::from("./assets/3-links/vehicles.xml"));
         let mut population = Population::part_from_file(
@@ -348,7 +348,7 @@ mod tests {
         let network = Network::from_file(
             "./assets/3-links/3-links-network.xml",
             1,
-            PartitionMethod::Metis,
+            PartitionMethod::Metis(MetisOptions::default()),
         );
         let mut garage = Garage::from_file(&PathBuf::from("./assets/3-links/vehicles.xml"));
         let mut population = Population::part_from_file(

--- a/src/simulation/replanning/routing/alt_router.rs
+++ b/src/simulation/replanning/routing/alt_router.rs
@@ -272,7 +272,7 @@ mod tests {
     use std::collections::HashMap;
     use std::path::PathBuf;
 
-    use crate::simulation::config::PartitionMethod;
+    use crate::simulation::config::{MetisOptions, PartitionMethod};
     use crate::simulation::id::Id;
     use crate::simulation::network::global_network::Network;
     use crate::simulation::replanning::routing::alt_router::{AltQueryResult, AltRouter};
@@ -313,7 +313,7 @@ mod tests {
         let network = Network::from_file(
             "./assets/adhoc_routing/no_updates/network.xml",
             1,
-            PartitionMethod::Metis,
+            PartitionMethod::Metis(MetisOptions::default()),
         );
         let garage = Garage::from_file(&PathBuf::from("./assets/adhoc_routing/vehicles.xml"));
 

--- a/src/simulation/replanning/routing/graph.rs
+++ b/src/simulation/replanning/routing/graph.rs
@@ -140,7 +140,7 @@ impl Graph {
 
 #[cfg(test)]
 pub(crate) mod tests {
-    use crate::simulation::config::PartitionMethod;
+    use crate::simulation::config::{MetisOptions, PartitionMethod};
     use std::collections::HashMap;
 
     use crate::simulation::network::global_network::Network;
@@ -151,7 +151,7 @@ pub(crate) mod tests {
         let network = Network::from_file(
             "./assets/routing_tests/triangle-network.xml",
             1,
-            PartitionMethod::Metis,
+            PartitionMethod::Metis(MetisOptions::default()),
         );
         NetworkConverter::convert_network(&network, None, None)
     }

--- a/src/simulation/replanning/routing/graph.rs
+++ b/src/simulation/replanning/routing/graph.rs
@@ -75,7 +75,7 @@ impl ForwardBackwardGraph {
 
     pub fn clone_with_new_travel_times_by_link(
         &self,
-        new_travel_times_by_link: HashMap<&u64, &u32>,
+        new_travel_times_by_link: HashMap<u64, u32>,
     ) -> ForwardBackwardGraph {
         ForwardBackwardGraph {
             forward_graph: self
@@ -114,13 +114,13 @@ impl Graph {
 
     pub fn clone_with_new_travel_times_by_link(
         &self,
-        new_travel_times_by_link: &HashMap<&u64, &u32>,
+        new_travel_times_by_link: &HashMap<u64, u32>,
     ) -> Graph {
         assert_eq!(self.link_ids.len(), self.travel_time.len());
 
         let mut new_travel_time_vector = Vec::new();
         for (index, &id) in self.link_ids.iter().enumerate() {
-            if let Some(&&new_travel_time) = new_travel_times_by_link.get(&(id)) {
+            if let Some(&new_travel_time) = new_travel_times_by_link.get(&(id)) {
                 new_travel_time_vector.push(new_travel_time);
                 debug!("Link {:?} | new travel time {:?}", id, new_travel_time);
             } else {
@@ -197,7 +197,7 @@ pub(crate) mod tests {
     fn clone_with_change() {
         let mut graph = get_triangle_test_graph();
         let mut change = HashMap::new();
-        change.insert(&5, &42);
+        change.insert(5, 42);
         let new_graph = graph.clone_with_new_travel_times_by_link(change);
 
         //change manually

--- a/src/simulation/replanning/routing/network_converter.rs
+++ b/src/simulation/replanning/routing/network_converter.rs
@@ -152,7 +152,7 @@ impl NetworkConverter {
 mod test {
     use std::path::PathBuf;
 
-    use crate::simulation::config::PartitionMethod;
+    use crate::simulation::config::{MetisOptions, PartitionMethod};
     use crate::simulation::id::Id;
     use crate::simulation::network::global_network::Network;
     use crate::simulation::replanning::routing::network_converter::NetworkConverter;
@@ -165,7 +165,7 @@ mod test {
         let network = Network::from_file(
             "./assets/routing_tests/triangle-network.xml",
             1,
-            PartitionMethod::Metis,
+            PartitionMethod::Metis(MetisOptions::default()),
         );
         let graph = NetworkConverter::convert_network(&network, None, None);
 
@@ -186,7 +186,7 @@ mod test {
         let network = Network::from_file(
             "./assets/routing_tests/network_different_modes.xml",
             1,
-            PartitionMethod::Metis,
+            PartitionMethod::Metis(MetisOptions::default()),
         );
 
         let mut garage = Garage::new();
@@ -228,7 +228,7 @@ mod test {
         let network = Network::from_file(
             "./assets/adhoc_routing/no_updates/network.xml",
             1,
-            PartitionMethod::Metis,
+            PartitionMethod::Metis(MetisOptions::default()),
         );
         let garage = Garage::from_file(&PathBuf::from("./assets/adhoc_routing/vehicles.xml"));
 

--- a/src/simulation/replanning/routing/travel_times_collecting_alt_router.rs
+++ b/src/simulation/replanning/routing/travel_times_collecting_alt_router.rs
@@ -149,7 +149,7 @@ impl<C: SimCommunicator> TravelTimesCollectingAltRouter<C> {
             let mut extended_travel_times_by_link_id = HashMap::new();
             for id in &self.link_ids_of_process {
                 if let Some(travel_time) = collected_travel_times.get(id) {
-                    // for each collected travel time: add if currently known travel time is different
+                    // add collected travel time
                     let initial = router.get_initial_travel_time(*id);
 
                     if initial.is_none() {
@@ -157,21 +157,16 @@ impl<C: SimCommunicator> TravelTimesCollectingAltRouter<C> {
                     }
 
                     let new_travel_time = (*travel_time).max(initial.unwrap());
-                    let current_travel_time = router.get_current_travel_time(*id).expect("If there is an initial travel time, there also must be a current travel time");
-                    if new_travel_time != current_travel_time {
-                        extended_travel_times_by_link_id.insert(*id, new_travel_time);
-                    }
+                    extended_travel_times_by_link_id.insert(*id, new_travel_time);
                 } else {
-                    // for each link which has no new travel time: add initial travel time if currently known travel time is different
+                    // add initial travel time for each link which has no new travel time
                     let initial = router.get_initial_travel_time(*id);
 
                     if initial.is_none() {
                         continue;
                     }
 
-                    if router.get_current_travel_time(*id) != initial {
-                        extended_travel_times_by_link_id.insert(*id, initial.unwrap());
-                    }
+                    extended_travel_times_by_link_id.insert(*id, initial.unwrap());
                 }
             }
             result.insert(*mode, extended_travel_times_by_link_id);

--- a/src/simulation/replanning/routing/travel_times_collecting_alt_router.rs
+++ b/src/simulation/replanning/routing/travel_times_collecting_alt_router.rs
@@ -106,17 +106,15 @@ impl<C: SimCommunicator> TravelTimesCollectingAltRouter<C> {
             return;
         }
 
-        let travel_times_by_link = traffic_info_messages
-            .iter()
-            .map(|info| &info.travel_times_by_link_id)
-            .fold(HashMap::new(), |result, value| {
-                result.into_iter().chain(value).collect()
-            });
-
         let number_of_links_with_traffic_info = traffic_info_messages
             .iter()
             .map(|info| info.travel_times_by_link_id.len())
             .sum::<usize>();
+
+        let travel_times_by_link: HashMap<u64, u32> = traffic_info_messages
+            .into_iter()
+            .flat_map(|info| info.travel_times_by_link_id.into_iter())
+            .collect();
 
         assert_eq!(
             number_of_links_with_traffic_info,

--- a/src/simulation/replanning/walk_finder.rs
+++ b/src/simulation/replanning/walk_finder.rs
@@ -62,7 +62,7 @@ impl WalkFinder for EuclideanWalkFinder {
 mod tests {
     use std::path::PathBuf;
 
-    use crate::simulation::config::PartitionMethod;
+    use crate::simulation::config::{MetisOptions, PartitionMethod};
     use crate::simulation::id::Id;
     use crate::simulation::network::global_network::Network;
     use crate::simulation::population::population::Population;
@@ -75,7 +75,7 @@ mod tests {
         let network = Network::from_file(
             "./assets/equil/equil-network.xml",
             1,
-            PartitionMethod::Metis,
+            PartitionMethod::Metis(MetisOptions::default()),
         );
 
         let walk_finder = EuclideanWalkFinder::new();

--- a/tests/resources/3-links/3-links-config-1.yml
+++ b/tests/resources/3-links/3-links-config-1.yml
@@ -8,7 +8,9 @@ modules:
   partitioning:
     type: Partitioning
     num_parts: 1
-    method: Metis
+    method: !Metis
+      vertex_weight:
+        - Constant
   output:
     type: Output
     output_dir: ./test_output/simulation/execute_3_links_single_part

--- a/tests/resources/3-links/3-links-config-2.yml
+++ b/tests/resources/3-links/3-links-config-2.yml
@@ -8,7 +8,9 @@ modules:
   partitioning:
     type: Partitioning
     num_parts: 2
-    method: Metis
+    method: !Metis
+      vertex_weight:
+        - Constant
   output:
     type: Output
     output_dir: ./test_output/simulation/execute_3_links_2_parts

--- a/tests/resources/adhoc_routing/no_updates/config-1.yml
+++ b/tests/resources/adhoc_routing/no_updates/config-1.yml
@@ -8,7 +8,9 @@ modules:
   partitioning:
     type: Partitioning
     num_parts: 1
-    method: Metis
+    method: !Metis
+      vertex_weight:
+        - Constant
   output:
     type: Output
     output_dir: ./test_output/simulation/adhoc_routing/no_updates/one_part

--- a/tests/resources/adhoc_routing/no_updates/config-2.yml
+++ b/tests/resources/adhoc_routing/no_updates/config-2.yml
@@ -8,7 +8,9 @@ modules:
   partitioning:
     type: Partitioning
     num_parts: 2
-    method: Metis
+    method: !Metis
+      vertex_weight:
+        - Constant
   output:
     type: Output
     output_dir: ./test_output/simulation/adhoc_routing/no_updates/two_parts

--- a/tests/resources/adhoc_routing/with_updates/config-1.yml
+++ b/tests/resources/adhoc_routing/with_updates/config-1.yml
@@ -8,7 +8,9 @@ modules:
   partitioning:
     type: Partitioning
     num_parts: 1
-    method: Metis
+    method: !Metis
+      vertex_weight:
+        - Constant
   output:
     type: Output
     output_dir: ./test_output/simulation/adhoc_routing/with_updates/one_part

--- a/tests/resources/adhoc_routing/with_updates/config-2.yml
+++ b/tests/resources/adhoc_routing/with_updates/config-2.yml
@@ -8,7 +8,9 @@ modules:
   partitioning:
     type: Partitioning
     num_parts: 1
-    method: Metis
+    method: !Metis
+      vertex_weight:
+        - Constant
   output:
     type: Output
     output_dir: ./test_output/simulation/adhoc_routing/with_updates/two_parts


### PR DESCRIPTION
The goal of METIS is to partition a network in such a way that the number of cut edges is minimized. If edge weights are set, it minimizes the sum of the weights. 
You can also explicitly assign node weights (multiple of them) that constrain the partitioning problem. Additionally, there is a tolerance factor regarding the constraints in which the results are allowed to lie. 
See: https://www.lrz.de/services/software/mathematik/metis/metis_5_0.pdf 

This PR introduces new partitioning options to qsim. The struct `MetisOptions` holds them. It consists of
* `vertex_weight` which holds predefined weight options
* `edge_weight` which can be turned on to use capacity as edge weight
* `imbalance_factor` which is the allowed relative weight difference in comparison to equal distribution of weight among the partitions
