### PR TITLE
Performance profiling routing

### DIFF
--- a/assets/3-links/1-agent-generic-leg.xml
+++ b/assets/3-links/1-agent-generic-leg.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE population SYSTEM "http://www.matsim.org/files/dtd/population_v6.dtd">
+
+<population desc="single agent on three links network">
+    <person id="100">
+        <plan score="92.61490939414003" selected="yes">
+            <activity type="home" link="link1" x="0" y="0" end_time="9:00:00"/>
+            <leg mode="walk" dep_time="01:14:47">
+                <attributes>
+                    <attribute name="routingMode" class="java.lang.String">walk</attribute>
+                </attributes>
+                <route type="generic" start_link="link1" end_link="link3" trav_time="02:28:35" distance="9410.82609917142"></route>
+            </leg>
+            <activity type="errands" link="link3" x="12" y="5" start_time="15:51:00" />
+        </plan>
+    </person>
+</population>

--- a/assets/3-links/vehicles_same_net_mode.xml
+++ b/assets/3-links/vehicles_same_net_mode.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<vehicleDefinitions xmlns="http://www.matsim.org/files/dtd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.matsim.org/files/dtd http://www.matsim.org/files/dtd/vehicleDefinitions_v2.0.xsd">
+    <vehicleType id="car">
+        <attributes>
+        </attributes>
+        <description>abc</description>
+        <length meter="9.5"/>
+        <width meter="3.0"/>
+        <maximumVelocity meterPerSecond="42.0"/>
+        <passengerCarEquivalents pce="2.0"/>
+        <networkMode networkMode="car"/>
+        <flowEfficiencyFactor factor="1.5"/>
+    </vehicleType>
+    <vehicleType id="bike">
+        <attributes>
+        </attributes>
+        <description>This is a bike</description>
+        <length meter="2.0"/>
+        <width meter="1.0"/>
+        <maximumVelocity meterPerSecond="4.0"/>
+        <passengerCarEquivalents pce="0.25"/>
+        <networkMode networkMode="car"/>
+        <flowEfficiencyFactor factor="1.5"/>
+    </vehicleType>
+    <vehicleType id="walk">
+        <attributes>
+            <attribute name="lod" class="java.lang.String">teleported</attribute>
+        </attributes>
+        <description>This is a pair of shoes</description>
+        <length meter="0.5"/>
+        <width meter="1.0"/>
+        <maximumVelocity meterPerSecond="0.85"/>
+        <passengerCarEquivalents pce="0.1"/>
+        <networkMode networkMode="walk"/>
+        <flowEfficiencyFactor factor="10.0"/>
+    </vehicleType>
+</vehicleDefinitions>

--- a/assets/mode_dependent_routing/vehicle_definitions.xml
+++ b/assets/mode_dependent_routing/vehicle_definitions.xml
@@ -2,8 +2,10 @@
 <vehicleDefinitions xmlns="http://www.matsim.org/files/dtd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.matsim.org/files/dtd http://www.matsim.org/files/dtd/vehicleDefinitions_v1.0.xsd">
     <vehicleType id="car">
         <maximumVelocity meterPerSecond="20"/>
+        <networkMode networkMode="car"/>
     </vehicleType>
     <vehicleType id="bike">
         <maximumVelocity meterPerSecond="5"/>
+        <networkMode networkMode="car"/>
     </vehicleType>
 </vehicleDefinitions>

--- a/src/bin/convert_to_xml.rs
+++ b/src/bin/convert_to_xml.rs
@@ -1,0 +1,48 @@
+use std::path::PathBuf;
+
+use clap::Parser;
+use tracing::info;
+
+use rust_q_sim::simulation::config::PartitionMethod;
+use rust_q_sim::simulation::network::global_network::Network;
+use rust_q_sim::simulation::population::population::Population;
+use rust_q_sim::simulation::vehicles::garage::Garage;
+
+#[derive(Parser, Debug)]
+struct InputArgs {
+    #[arg(short, long)]
+    pub network: String,
+    #[arg(short, long)]
+    pub population: String,
+    #[arg(short, long)]
+    pub vehicles: String,
+    #[arg(short, long)]
+    pub ids: String,
+}
+
+fn main() {
+    rust_q_sim::simulation::logging::init_std_out_logging();
+    let args = InputArgs::parse();
+    let net_path = PathBuf::from(&args.network);
+    let pop_path = PathBuf::from(&args.population);
+    let veh_path = PathBuf::from(&args.vehicles);
+    let ids_path = PathBuf::from(&args.ids);
+
+    rust_q_sim::simulation::id::load_from_file(&ids_path);
+    let net = Network::from_file_path(&net_path, 1, PartitionMethod::None);
+    let mut veh = Garage::from_file(&veh_path);
+    let pop = Population::from_file(&pop_path, &mut veh);
+
+    net.to_file(&replace_filename(net_path));
+    veh.to_file(&replace_filename(veh_path));
+    pop.to_file(&replace_filename(pop_path))
+}
+
+fn replace_filename(path: PathBuf) -> PathBuf {
+    let file_name = path.file_name().unwrap().to_str().unwrap();
+    let stripped = file_name.strip_suffix(".binpb");
+    let new_file_name = format!("{}.xml.gz", stripped.unwrap());
+    info!("New file name: {}", new_file_name);
+    let result = path.parent().unwrap().join(new_file_name);
+    result
+}

--- a/src/simulation/messaging/events.rs
+++ b/src/simulation/messaging/events.rs
@@ -1,5 +1,6 @@
 use std::any::Any;
 use std::collections::HashMap;
+use std::fmt::Debug;
 
 use tracing::{info, instrument};
 
@@ -21,6 +22,12 @@ pub trait EventsSubscriber {
     fn as_any(&mut self) -> &mut dyn Any;
 }
 
+impl Debug for dyn EventsSubscriber + Send {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "EventsSubscriber")
+    }
+}
+
 pub struct EventsLogger {}
 
 impl EventsSubscriber for EventsLogger {
@@ -33,7 +40,7 @@ impl EventsSubscriber for EventsLogger {
     }
 }
 
-#[derive(Default)]
+#[derive(Default, Debug)]
 pub struct EventsPublisher {
     handlers: Vec<Box<dyn EventsSubscriber + Send>>,
 }

--- a/src/simulation/population/population.rs
+++ b/src/simulation/population/population.rs
@@ -7,7 +7,7 @@ use crate::simulation::population::io::{from_file, to_file};
 use crate::simulation::vehicles::garage::Garage;
 use crate::simulation::wire_types::population::Person;
 
-#[derive(Debug, Default)]
+#[derive(Debug, Default, PartialEq)]
 pub struct Population {
     pub persons: HashMap<Id<Person>, Person>,
 }
@@ -173,5 +173,26 @@ mod tests {
         // has all the agents and the other doesn't
         assert!(pop1.persons.len() == 100 || pop2.persons.len() == 100);
         assert!(pop1.persons.is_empty() || pop2.persons.is_empty());
+    }
+
+    #[test]
+    fn test_from_xml_to_binpb_same() {
+        let net = Network::from_file(
+            "./assets/equil/equil-network.xml",
+            2,
+            PartitionMethod::Metis(MetisOptions::default()),
+        );
+        let mut garage = Garage::from_file(&PathBuf::from("./assets/equil/equil-vehicles.xml"));
+        let population = Population::part_from_file(
+            &PathBuf::from("./assets/equil/equil-plans.xml.gz"),
+            &net,
+            &mut garage,
+            0,
+        );
+
+        let temp_file = PathBuf::from("./assets/equil/equil-plans.binpb");
+        population.to_file(&temp_file);
+        let population2 = Population::part_from_file(&temp_file, &net, &mut garage, 0);
+        assert_eq!(population, population2);
     }
 }

--- a/src/simulation/population/population_data.rs
+++ b/src/simulation/population/population_data.rs
@@ -7,8 +7,10 @@ use crate::simulation::population::io::{
     IOActivity, IOLeg, IOPerson, IOPlan, IOPlanElement, IORoute,
 };
 use crate::simulation::time_queue::EndTime;
+use crate::simulation::vehicles::garage::Garage;
 use crate::simulation::wire_types::messages::Vehicle;
 use crate::simulation::wire_types::population::{Activity, Leg, Person, Plan, Route};
+use crate::simulation::wire_types::vehicles::VehicleType;
 
 impl Person {
     pub fn from_io(io_person: &IOPerson) -> Person {
@@ -361,13 +363,17 @@ impl Leg {
         }
     }
 
-    pub fn access_eggress(mode: u64) -> Self {
+    pub fn access_eggress(net_mode: u64, veh_type_id: u64) -> Self {
         Leg {
-            mode,
-            routing_mode: mode,
+            mode: net_mode,
+            routing_mode: net_mode,
             dep_time: None,
             trav_time: 0,
-            route: None,
+            route: Some(Route {
+                veh_id: veh_type_id,
+                distance: 0.0,
+                route: Vec::new(),
+            }),
         }
     }
 
@@ -379,6 +385,13 @@ impl Leg {
         } else {
             0
         }
+    }
+
+    pub fn vehicle_type_id<'gar>(&self, garage: &'gar Garage) -> &'gar Id<VehicleType> {
+        self.route
+            .as_ref()
+            .map(|r| garage.vehicles.get(&Id::<Vehicle>::get(r.veh_id)).unwrap())
+            .unwrap()
     }
 }
 

--- a/src/simulation/replanning/mod.rs
+++ b/src/simulation/replanning/mod.rs
@@ -1,3 +1,3 @@
 pub mod replanner;
 pub mod routing;
-pub mod walk_finder;
+pub mod teleported_router;

--- a/src/simulation/replanning/replanner.rs
+++ b/src/simulation/replanning/replanner.rs
@@ -357,12 +357,53 @@ mod tests {
     #[test]
     fn test_update_main_leg() {
         //prepare
+        let mut garage = Garage::from_file(&PathBuf::from("./assets/3-links/vehicles.xml"));
+
+        let population = advance_plan_and_update_main_leg(&mut garage);
+        let agent_id = Id::get_from_ext("100");
+        let agent = population.persons.get(&agent_id).unwrap();
+
+        //check main leg
+        let main_leg = agent.plan.as_ref().unwrap().legs.get(1);
+        assert_eq!(
+            main_leg.unwrap().route.as_ref().unwrap(),
+            &Route {
+                veh_id: 0,
+                distance: 1200.,
+                route: vec![0, 1, 2],
+            }
+        );
+    }
+
+    #[test]
+    fn test_update_main_leg_with_same_net_modes_in_veh_type() {
+        //prepare
+        let mut garage = Garage::from_file(&PathBuf::from(
+            "./assets/3-links/vehicles_same_net_mode.xml",
+        ));
+
+        let population = advance_plan_and_update_main_leg(&mut garage);
+        let agent_id = Id::get_from_ext("100");
+        let agent = population.persons.get(&agent_id).unwrap();
+
+        //check main leg
+        let main_leg = agent.plan.as_ref().unwrap().legs.get(1);
+        assert_eq!(
+            main_leg.unwrap().route.as_ref().unwrap(),
+            &Route {
+                veh_id: 0,
+                distance: 1200.,
+                route: vec![0, 1, 2],
+            }
+        );
+    }
+
+    fn advance_plan_and_update_main_leg(mut garage: &mut Garage) -> Population {
         let network = Network::from_file(
             "./assets/3-links/3-links-network.xml",
             1,
             PartitionMethod::Metis(MetisOptions::default()),
         );
-        let mut garage = Garage::from_file(&PathBuf::from("./assets/3-links/vehicles.xml"));
         let mut population = Population::part_from_file(
             &PathBuf::from("./assets/3-links/1-agent-trip-leg.xml"),
             &network,
@@ -387,17 +428,7 @@ mod tests {
 
         //do change
         replanner.replan(0, &mut agent, &garage);
-
-        //check main leg
-        let main_leg = agent.plan.as_ref().unwrap().legs.get(1);
-        assert_eq!(
-            main_leg.unwrap().route.as_ref().unwrap(),
-            &Route {
-                veh_id: 0,
-                distance: 1200.,
-                route: vec![0, 1, 2],
-            }
-        );
+        population
     }
 
     fn get_act_type_id(agent: &Person, act_index: usize) -> Id<String> {

--- a/src/simulation/replanning/replanner.rs
+++ b/src/simulation/replanning/replanner.rs
@@ -33,6 +33,7 @@ impl Replanner for DummyReplanner {
     fn replan(&self, _now: u32, _agent: &mut Person, _garage: &Garage) {}
 }
 
+#[derive(Debug)]
 pub struct ReRouteTripReplanner {
     router: Box<dyn Router>,
     walk_finder: Box<dyn WalkFinder>,
@@ -40,10 +41,12 @@ pub struct ReRouteTripReplanner {
 }
 
 impl Replanner for ReRouteTripReplanner {
+    #[tracing::instrument(level = "trace", skip(self, events))]
     fn update_time(&mut self, now: u32, events: &mut EventsPublisher) {
         self.router.next_time_step(now, events)
     }
 
+    // #[tracing::instrument(level = "trace", skip(self, agent, garage))]
     fn replan(&self, _now: u32, agent: &mut Person, garage: &Garage) {
         let leg_type = Self::get_leg_type(agent);
         if leg_type == LegType::TripPlaceholder {

--- a/src/simulation/replanning/replanner.rs
+++ b/src/simulation/replanning/replanner.rs
@@ -7,13 +7,13 @@ use crate::simulation::messaging::communication::communicators::SimCommunicator;
 use crate::simulation::messaging::events::EventsPublisher;
 use crate::simulation::network::global_network::{Link, Network};
 use crate::simulation::network::sim_network::SimNetworkPartition;
-use crate::simulation::replanning::routing::router::Router;
+use crate::simulation::replanning::routing::router::NetworkRouter;
 use crate::simulation::replanning::routing::travel_times_collecting_alt_router::TravelTimesCollectingAltRouter;
-use crate::simulation::replanning::walk_finder::{EuclideanWalkFinder, WalkFinder};
+use crate::simulation::replanning::teleported_router::{BeeLineDistanceRouter, TeleportedRouter};
 use crate::simulation::vehicles::garage::Garage;
 use crate::simulation::wire_types::messages::Vehicle;
 use crate::simulation::wire_types::population::{Activity, Leg, Person};
-use crate::simulation::wire_types::vehicles::VehicleType;
+use crate::simulation::wire_types::vehicles::{LevelOfDetail, VehicleType};
 
 pub trait Replanner {
     fn update_time(&mut self, now: u32, events: &mut EventsPublisher);
@@ -22,9 +22,10 @@ pub trait Replanner {
 
 #[derive(Eq, PartialEq)]
 enum LegType {
-    AccessEgress,
-    Main,
     TripPlaceholder,
+    AccessEgress,
+    MainTeleported,
+    MainNetwork,
 }
 
 pub struct DummyReplanner {}
@@ -37,29 +38,32 @@ impl Replanner for DummyReplanner {
 
 #[derive(Debug)]
 pub struct ReRouteTripReplanner {
-    router: Box<dyn Router>,
-    walk_finder: Box<dyn WalkFinder>,
+    network_router: Box<dyn NetworkRouter>,
+    teleported_router: Box<dyn TeleportedRouter>,
     global_network: Network,
 }
 
 impl Replanner for ReRouteTripReplanner {
     #[tracing::instrument(level = "trace", skip(self, events))]
     fn update_time(&mut self, now: u32, events: &mut EventsPublisher) {
-        self.router.next_time_step(now, events)
+        self.network_router.next_time_step(now, events)
     }
 
     // #[tracing::instrument(level = "trace", skip(self, agent, garage))]
     fn replan(&self, _now: u32, agent: &mut Person, garage: &Garage) {
-        let leg_type = Self::get_leg_type(agent);
+        let leg_type = Self::get_leg_type(agent, garage);
         if leg_type == LegType::TripPlaceholder {
             self.insert_access_egress(agent, garage);
         }
 
         match leg_type {
+            // in case of trip placeholder: we have inserted access and egress legs before
+            // => we must now replan the respective access leg
             LegType::AccessEgress | LegType::TripPlaceholder => {
                 self.replan_access_egress(agent, garage)
             }
-            LegType::Main => self.replan_main(agent, garage),
+            LegType::MainNetwork => self.replan_main(agent, garage),
+            LegType::MainTeleported => self.replan_teleported_main(agent, garage),
         };
     }
 }
@@ -77,17 +81,17 @@ impl ReRouteTripReplanner {
                 &garage.vehicle_types,
             );
 
-        let router: Box<dyn Router> = Box::new(TravelTimesCollectingAltRouter::new(
+        let router: Box<dyn NetworkRouter> = Box::new(TravelTimesCollectingAltRouter::new(
             forward_backward_graph_by_veh_type,
             communicator,
             sim_network.get_link_ids(),
         ));
 
-        let walk_finder: Box<dyn WalkFinder> = Box::new(EuclideanWalkFinder::new());
+        let teleported_router: Box<dyn TeleportedRouter> = Box::new(BeeLineDistanceRouter::new());
 
         ReRouteTripReplanner {
-            router,
-            walk_finder,
+            network_router: router,
+            teleported_router,
             global_network: global_network.clone(),
         }
     }
@@ -164,18 +168,25 @@ impl ReRouteTripReplanner {
         assert_eq!(curr_act.link_id, next_act.link_id);
 
         let veh_type_id = agent.next_leg().vehicle_type_id(garage);
-
         let access_egress_speed = garage.vehicle_types.get(veh_type_id).unwrap().max_v;
 
         let dep_time;
         let walk = if curr_act.is_interaction() {
             dep_time = curr_act.end_time;
-            self.walk_finder
-                .find_walk(next_act, access_egress_speed, &self.global_network)
+            // curr activity is interaction => it's an egress leg => next activity has location
+            self.teleported_router.query_access_egress(
+                next_act,
+                access_egress_speed,
+                &self.global_network,
+            )
         } else {
             dep_time = curr_act.end_time;
-            self.walk_finder
-                .find_walk(curr_act, access_egress_speed, &self.global_network)
+            // curr activity is an actual activity => it's an access leg => curr activity has location
+            self.teleported_router.query_access_egress(
+                curr_act,
+                access_egress_speed,
+                &self.global_network,
+            )
         };
 
         let vehicle_id = garage.veh_id(&Id::<Person>::get(agent.id), veh_type_id);
@@ -189,15 +200,37 @@ impl ReRouteTripReplanner {
         );
     }
 
+    fn replan_teleported_main(&self, agent: &mut Person, garage: &Garage) {
+        let curr_act = agent.curr_act();
+        let next_act = agent.next_act();
+
+        let veh_type_id = agent.next_leg().vehicle_type_id(garage);
+        let speed = garage.vehicle_types.get(veh_type_id).unwrap().max_v;
+
+        let dep_time = curr_act.end_time;
+        let teleportation = self
+            .teleported_router
+            .query_between_acts(curr_act, next_act, speed);
+
+        let vehicle_id = garage.veh_id(&Id::<Person>::get(agent.id), veh_type_id);
+        agent.update_next_leg(
+            dep_time,
+            teleportation.duration,
+            vec![agent.curr_act().link_id, agent.next_act().link_id],
+            teleportation.distance,
+            vehicle_id.internal(),
+        );
+    }
+
     fn find_route(
         &self,
         from_act: &Activity,
         to_act: &Activity,
         veh_type_id: &Id<VehicleType>,
     ) -> (Vec<u64>, Option<u32>) {
-        let query_result = self
-            .router
-            .query_links(from_act.link_id, to_act.link_id, veh_type_id);
+        let query_result =
+            self.network_router
+                .query_links(from_act.link_id, to_act.link_id, veh_type_id);
 
         let route = query_result.path.expect("There is no route!");
         let travel_time = query_result.travel_time;
@@ -210,7 +243,7 @@ impl ReRouteTripReplanner {
     }
 
     #[allow(clippy::if_same_then_else)]
-    fn get_leg_type(agent: &Person) -> LegType {
+    fn get_leg_type(agent: &Person, garage: &Garage) -> LegType {
         //act - leg - interaction act => walk
         if !agent.curr_act().is_interaction() && agent.next_act().is_interaction() {
             LegType::AccessEgress
@@ -219,13 +252,35 @@ impl ReRouteTripReplanner {
         else if agent.curr_act().is_interaction() && !agent.next_act().is_interaction() {
             LegType::AccessEgress
         }
-        //interaction act - leg - interaction act => main leg
+        //interaction act - leg - interaction act => main leg if network, generic if teleported
         else if agent.curr_act().is_interaction() && agent.next_act().is_interaction() {
-            LegType::Main
+            let level_of_detail = LevelOfDetail::try_from(
+                garage
+                    .vehicle_types
+                    .get(agent.next_leg().vehicle_type_id(garage))
+                    .unwrap()
+                    .lod,
+            )
+            .expect("Unknown level of detail");
+            match level_of_detail {
+                LevelOfDetail::Network => LegType::MainNetwork,
+                LevelOfDetail::Teleported => LegType::MainTeleported,
+            }
         }
-        //act - leg - act => dummy leg
+        //act - leg - act => trip placeholder if network, generic if teleported
         else if !agent.curr_act().is_interaction() && !agent.next_act().is_interaction() {
-            LegType::TripPlaceholder
+            let level_of_detail = LevelOfDetail::try_from(
+                garage
+                    .vehicle_types
+                    .get(agent.next_leg().vehicle_type_id(garage))
+                    .unwrap()
+                    .lod,
+            )
+            .expect("Unknown level of detail");
+            match level_of_detail {
+                LevelOfDetail::Network => LegType::TripPlaceholder,
+                LevelOfDetail::Teleported => LegType::MainTeleported,
+            }
         } else {
             panic!("Computing a leg between two main activities should never happen.")
         }
@@ -352,6 +407,57 @@ mod tests {
                 .distance,
             10.
         );
+    }
+
+    #[test]
+    fn test_update_teleported_main() {
+        //prepare
+        let network = Network::from_file(
+            "./assets/3-links/3-links-network.xml",
+            1,
+            PartitionMethod::Metis(MetisOptions::default()),
+        );
+        let mut garage = Garage::from_file(&PathBuf::from("./assets/3-links/vehicles.xml"));
+        let mut population = Population::part_from_file(
+            &PathBuf::from("./assets/3-links/1-agent-generic-leg.xml"),
+            &network,
+            &mut garage,
+            0,
+        );
+
+        let sim_net = SimNetworkPartition::from_network(&network, 0, 1.0);
+        let agent_id = Id::get_from_ext("100");
+        let mut agent = population.persons.get_mut(&agent_id).unwrap();
+
+        let replanner =
+            ReRouteTripReplanner::new(&network, &sim_net, &garage, Rc::new(DummySimCommunicator()));
+
+        //do change
+        replanner.replan(0, &mut agent, &garage);
+
+        //check activities
+        assert_eq!(agent.plan.as_ref().unwrap().acts.len(), 2);
+
+        //check legs
+        assert_eq!(agent.plan.as_ref().unwrap().legs.len(), 1);
+        assert_eq!(get_veh_type_id(&agent, 0, &garage).external(), "walk");
+        let route = agent
+            .plan
+            .as_ref()
+            .unwrap()
+            .legs
+            .get(0)
+            .unwrap()
+            .route
+            .as_ref()
+            .unwrap();
+
+        //distance from (0,0) to (12,5) is 13
+        assert_eq!(13., route.distance);
+        assert_eq!(
+            (13. / 0.85) as u32,
+            agent.plan.as_ref().unwrap().legs.get(0).unwrap().trav_time
+        )
     }
 
     #[test]

--- a/src/simulation/replanning/routing/alt_router.rs
+++ b/src/simulation/replanning/routing/alt_router.rs
@@ -279,6 +279,7 @@ mod tests {
     use crate::simulation::replanning::routing::graph::tests::get_triangle_test_graph;
     use crate::simulation::replanning::routing::network_converter::NetworkConverter;
     use crate::simulation::vehicles::garage::Garage;
+    use crate::simulation::wire_types::vehicles::VehicleType;
 
     fn query_and_check(
         router: &AltRouter,
@@ -320,8 +321,8 @@ mod tests {
         let graph_by_vehicle_type =
             NetworkConverter::convert_network_with_vehicle_types(&network, &garage.vehicle_types);
 
-        let bike_id = &Id::<String>::get_from_ext("bike").internal();
-        let car_id = &Id::<String>::get_from_ext("car").internal();
+        let bike_id = &Id::<VehicleType>::get_from_ext("bike");
+        let car_id = &Id::<VehicleType>::get_from_ext("car");
 
         let router_by_vehicle_type = graph_by_vehicle_type
             .into_iter()

--- a/src/simulation/replanning/routing/graph.rs
+++ b/src/simulation/replanning/routing/graph.rs
@@ -1,7 +1,5 @@
 use std::collections::HashMap;
 
-use tracing::debug;
-
 #[derive(Clone, Debug, PartialEq)]
 pub struct ForwardBackwardGraph {
     pub forward_graph: Graph,
@@ -122,7 +120,6 @@ impl Graph {
         for (index, &id) in self.link_ids.iter().enumerate() {
             if let Some(&new_travel_time) = new_travel_times_by_link.get(&(id)) {
                 new_travel_time_vector.push(new_travel_time);
-                debug!("Link {:?} | new travel time {:?}", id, new_travel_time);
             } else {
                 new_travel_time_vector.push(*self.travel_time.get(index).unwrap())
             }

--- a/src/simulation/replanning/routing/graph.rs
+++ b/src/simulation/replanning/routing/graph.rs
@@ -153,7 +153,7 @@ pub(crate) mod tests {
             1,
             PartitionMethod::Metis(MetisOptions::default()),
         );
-        NetworkConverter::convert_network(&network, None, None)
+        NetworkConverter::convert_network(&network, None)
     }
 
     #[test]

--- a/src/simulation/replanning/routing/network_converter.rs
+++ b/src/simulation/replanning/routing/network_converter.rs
@@ -256,4 +256,39 @@ mod test {
         let link2_index = bike_graph.forward_graph.first_out[2];
         assert_eq!(bike_graph.forward_graph.travel_time[link2_index], 200);
     }
+
+    #[test]
+    fn test_different_veh_types_same_net_mode() {
+        let network = Network::from_file(
+            "./assets/adhoc_routing/no_updates/network.xml",
+            1,
+            PartitionMethod::Metis(MetisOptions::default()),
+        );
+        let garage = Garage::from_file(&PathBuf::from(
+            "./assets/mode_dependent_routing/vehicle_definitions.xml",
+        ));
+
+        let vehicle_type2graph =
+            NetworkConverter::convert_network_with_vehicle_types(&network, &garage.vehicle_types);
+
+        assert_eq!(vehicle_type2graph.keys().len(), 2);
+
+        assert_eq!(
+            vehicle_type2graph
+                .get(&Id::<VehicleType>::get_from_ext("car"))
+                .unwrap()
+                .forward_graph
+                .travel_time,
+            vec![10, 10, 50, 100, 10, 10, 50]
+        );
+
+        assert_eq!(
+            vehicle_type2graph
+                .get(&Id::<VehicleType>::get_from_ext("bike"))
+                .unwrap()
+                .forward_graph
+                .travel_time,
+            vec![20, 20, 200, 200, 20, 20, 200]
+        );
+    }
 }

--- a/src/simulation/replanning/routing/router.rs
+++ b/src/simulation/replanning/routing/router.rs
@@ -1,9 +1,16 @@
 use crate::simulation::messaging::events::EventsPublisher;
+use std::fmt::Debug;
 
 pub trait Router {
     fn query_links(&self, from_link: u64, to_link: u64, mode: u64) -> CustomQueryResult;
 
     fn next_time_step(&mut self, now: u32, events: &mut EventsPublisher);
+}
+
+impl Debug for dyn Router {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "Router")
+    }
 }
 
 pub struct CustomQueryResult {

--- a/src/simulation/replanning/routing/router.rs
+++ b/src/simulation/replanning/routing/router.rs
@@ -1,8 +1,15 @@
+use crate::simulation::id::Id;
 use crate::simulation::messaging::events::EventsPublisher;
+use crate::simulation::wire_types::vehicles::VehicleType;
 use std::fmt::Debug;
 
 pub trait Router {
-    fn query_links(&self, from_link: u64, to_link: u64, mode: u64) -> CustomQueryResult;
+    fn query_links(
+        &self,
+        from_link: u64,
+        to_link: u64,
+        veh_type_id: &Id<VehicleType>,
+    ) -> CustomQueryResult;
 
     fn next_time_step(&mut self, now: u32, events: &mut EventsPublisher);
 }

--- a/src/simulation/replanning/routing/router.rs
+++ b/src/simulation/replanning/routing/router.rs
@@ -3,7 +3,7 @@ use crate::simulation::messaging::events::EventsPublisher;
 use crate::simulation::wire_types::vehicles::VehicleType;
 use std::fmt::Debug;
 
-pub trait Router {
+pub trait NetworkRouter {
     fn query_links(
         &self,
         from_link: u64,
@@ -14,9 +14,9 @@ pub trait Router {
     fn next_time_step(&mut self, now: u32, events: &mut EventsPublisher);
 }
 
-impl Debug for dyn Router {
+impl Debug for dyn NetworkRouter {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "Router")
+        write!(f, "NetworkRouter")
     }
 }
 

--- a/src/simulation/replanning/routing/travel_times_collecting_alt_router.rs
+++ b/src/simulation/replanning/routing/travel_times_collecting_alt_router.rs
@@ -3,7 +3,7 @@ use std::fmt::Debug;
 use std::rc::Rc;
 
 use nohash_hasher::IntMap;
-use tracing::debug;
+use tracing::{debug, info};
 
 use crate::simulation::id::Id;
 use crate::simulation::messaging::communication::communicators::SimCommunicator;
@@ -111,6 +111,14 @@ impl<C: SimCommunicator> TravelTimesCollectingAltRouter<C> {
             .iter()
             .map(|(&m, g)| (m, AltRouter::new(g.clone())))
             .collect::<BTreeMap<_, _>>();
+
+        info!(
+            "Created TravelTimesCollectingAltRouter with modes: {:?}",
+            router_by_mode
+                .keys()
+                .map(|k| (k, String::from(Id::<String>::get(*k).external())))
+                .collect::<HashMap<&u64, String>>()
+        );
 
         TravelTimesCollectingAltRouter {
             router_by_mode,

--- a/src/simulation/replanning/walk_finder.rs
+++ b/src/simulation/replanning/walk_finder.rs
@@ -1,10 +1,17 @@
 use geo::{Closest, ClosestPoint, EuclideanDistance, Line, Point};
+use std::fmt::Debug;
 
 use crate::simulation::network::global_network::Network;
 use crate::simulation::wire_types::population::Activity;
 
 pub trait WalkFinder {
     fn find_walk(&self, curr_act: &Activity, access_egress_speed: f32, network: &Network) -> Walk;
+}
+
+impl Debug for dyn WalkFinder {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "WalkFinder")
+    }
 }
 
 #[derive(PartialEq, Debug, Clone, Copy)]

--- a/src/simulation/vehicles/garage.rs
+++ b/src/simulation/vehicles/garage.rs
@@ -82,8 +82,8 @@ impl Garage {
          */
     }
 
-    pub fn get_mode_veh_id(&self, person_id: &Id<Person>, mode: &Id<String>) -> Id<Vehicle> {
-        let external = format!("{}_{}", person_id.external(), mode.external());
+    pub fn veh_id(&self, person_id: &Id<Person>, veh_type_id: &Id<VehicleType>) -> Id<Vehicle> {
+        let external = format!("{}_{}", person_id.external(), veh_type_id.external());
         Id::get_from_ext(&external)
     }
 
@@ -151,7 +151,7 @@ mod tests {
         let mut garage = Garage::new();
         let type_id = Id::create("some-type");
         let mode = Id::new_internal(0);
-        let veh_type = create_vehicle_type(type_id, mode);
+        let veh_type = create_vehicle_type(&type_id, mode);
 
         garage.add_veh_type(veh_type);
 
@@ -164,8 +164,8 @@ mod tests {
         let mut garage = Garage::new();
         let type_id = Id::create("some-type");
         let mode = Id::new_internal(0);
-        let veh_type1 = create_vehicle_type(type_id.clone(), mode.clone());
-        let veh_type2 = create_vehicle_type(type_id.clone(), mode.clone());
+        let veh_type1 = create_vehicle_type(&type_id, mode.clone());
+        let veh_type2 = create_vehicle_type(&type_id, mode.clone());
 
         garage.add_veh_type(veh_type1);
         garage.add_veh_type(veh_type2);

--- a/src/simulation/vehicles/io.rs
+++ b/src/simulation/vehicles/io.rs
@@ -25,7 +25,7 @@ pub fn from_file(path: &Path) -> Garage {
 pub fn to_file(garage: &Garage, path: &Path) {
     if path.extension().unwrap().eq("binpb") {
         write_to_proto(garage, path);
-    } else if path.extension().unwrap().eq("xml") || path.ends_with("xml.gz") {
+    } else if path.extension().unwrap().eq("xml") || path.extension().unwrap().eq("gz") {
         write_to_xml(garage, path);
     } else {
         panic!("file format not supported. Either use `.xml`, `.xml.gz`, or `.binpb` as extension");

--- a/src/simulation/vehicles/mod.rs
+++ b/src/simulation/vehicles/mod.rs
@@ -1,2 +1,3 @@
 pub mod garage;
 mod io;
+mod vehicles;

--- a/src/simulation/vehicles/vehicles.rs
+++ b/src/simulation/vehicles/vehicles.rs
@@ -1,0 +1,13 @@
+use crate::simulation::wire_types::vehicles::LevelOfDetail;
+
+impl TryFrom<i32> for LevelOfDetail {
+    type Error = ();
+
+    fn try_from(value: i32) -> Result<Self, Self::Error> {
+        match value {
+            x if x == LevelOfDetail::Network as i32 => Ok(LevelOfDetail::Network),
+            x if x == LevelOfDetail::Teleported as i32 => Ok(LevelOfDetail::Teleported),
+            _ => Err(()),
+        }
+    }
+}

--- a/src/test_utils.rs
+++ b/src/test_utils.rs
@@ -28,7 +28,7 @@ pub fn create_folders(path: PathBuf) -> PathBuf {
     path
 }
 
-pub fn create_vehicle_type(id: Id<VehicleType>, net_mode: Id<String>) -> VehicleType {
+pub fn create_vehicle_type(id: &Id<VehicleType>, net_mode: Id<String>) -> VehicleType {
     VehicleType {
         id: id.internal(),
         length: 0.0,


### PR DESCRIPTION
Changes: 
* Introduce performance profiling for routing
* Routing depends on vehicle type, not on network mode
* Generic routes also get rerouted. The routing type (network or teleportation) only depends on the vehicle type. Structs got better names (`WalkFinder` --> `TeleportedRouter`) in order to be less specific. This router e.g. is now used for handling all teleported routing requests.